### PR TITLE
Pass HTTP error codes through ChefServerError instances

### DIFF
--- a/chef/api.py
+++ b/chef/api.py
@@ -122,7 +122,7 @@ class ChefAPI(object):
             err = e.read()
             try:
                 err = json.loads(err)
-                raise ChefServerError(err['error'])
+                raise ChefServerError(err['error'], code=e.code)
             except ValueError:
                 pass
             raise

--- a/chef/exceptions.py
+++ b/chef/exceptions.py
@@ -5,4 +5,8 @@ class ChefError(Exception):
     """Top-level Chef error."""
 
 class ChefServerError(ChefError):
-    """An error from a Chef server."""
+    """An error from a Chef server. May include a HTTP response code."""
+    def __init__(self, message, code=None):
+        ChefError.__init__(self, message)
+        self.code = code
+        


### PR DESCRIPTION
As the Chef API documents the semantics of each HTTP error code associated with the REST API, passing these codes back to the caller (encapsulated in the exception object) is a reasonable and useful behavior.
