### PR TITLE
Replace urllib2 with requests, add option to disable SSL cert verification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'Programming Language :: Python',
     ],
     zip_safe = False,
-    install_requires = ['six>=1.9.0'],
+    install_requires = ['six>=1.9.0','requests>=2.7.0'],
     tests_require = ['unittest2', 'mock'],
     test_suite = 'unittest2.collector',
 )


### PR DESCRIPTION
We have problems with our internally hosted chef server's SSL cert not being real, which is fine for us not facing the internet. Trying to disable validation with urllib2 is quite messy, so this patch:

- Replaces urllib2 with requests, which cleans things up nicely
- Adds an option to autoconfigure() that allows users to disable SSL certificate verification

