### PR TITLE
Update rsa.py

### DIFF
--- a/chef/rsa.py
+++ b/chef/rsa.py
@@ -5,7 +5,7 @@ from ctypes import *
 if sys.platform == 'win32' or sys.platform == 'cygwin':
     _eay = CDLL('libeay32.dll')
 elif sys.platform == 'darwin':
-    _eay = CDLL('libcrypto.dylib')
+    _eay = CDLL('/usr/lib/libcrypto.dylib')
 else:
     _eay = CDLL('libcrypto.so')
 


### PR DESCRIPTION
Mac OSX El Capitan has a new security feature that breaks pychef for me. I received the below error when trying to use pychef after upgrading to El Capitan. Making this small change was all that was needed to make it work again.
...
  File "/Library/Python/2.7/site-packages/chef/__init__.py", line 5, in <module>
    from chef.api import ChefAPI, autoconfigure
  File "/Library/Python/2.7/site-packages/chef/api.py", line 18, in <module>
    from chef.rsa import Key
  File "/Library/Python/2.7/site-packages/chef/rsa.py", line 7, in <module>
    _eay = CDLL('libcrypto.dylib')
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ctypes/__init__.py", line 365, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(libcrypto.dylib, 6): image not found