### PR TITLE
Add Python 3.5 testing to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
 install: pip install versiontools --use-mirrors
 script:  python setup.py test


### PR DESCRIPTION
Start testing on Python 3.5 too. Currently it all passes on my tests.