### PR TITLE
inject default values to from_config_file method

### DIFF
--- a/chef/api.py
+++ b/chef/api.py
@@ -74,7 +74,7 @@ class ChefAPI(object):
             self.set_default()
 
     @classmethod
-    def from_config_file(cls, path):
+    def from_config_file(cls, path, url=None, key_path=None, client_name=None):
         """Load Chef API paraters from a config file. Returns None if the
         config can't be used.
         """
@@ -83,7 +83,6 @@ class ChefAPI(object):
             # Can't even read the config file
             log.debug('Unable to read config file "%s"', path)
             return
-        url = key_path = client_name = None
         ssl_verify = True
         for line in open(path):
             if not line.strip() or line.startswith('#'):


### PR DESCRIPTION
for cases where there are no corresponding fields in the file

eg 
modern "/etc/chef/client.rb" files like:

chef_server_url "***"
client_fork true
log_location '/var/log/chef/client.log'
no_lazy_load true
validation_client_name "chef-validator"
verify_api_cert true
environment "testing"
node_name "***"

...