### PR TITLE
Fix for failing Fabric import in integration

### DIFF
--- a/chef/fabric.py
+++ b/chef/fabric.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import
+
 import six
 import functools
 


### PR DESCRIPTION
The fabric.api import fails in fabric.py as there is a name clash
unless you use absolute imports (which is the default in Python 3).
As the ImportError catches and doesn't warn, nobody could see the
module fabric.api failing to import.