### PR TITLE
Add policy_name and policy_group to node attributes

### DIFF
--- a/chef/node.py
+++ b/chef/node.py
@@ -196,7 +196,9 @@ class Node(ChefObject):
         'override': NodeAttributes,
         'automatic': NodeAttributes,
         'run_list': list,
-        'chef_environment': str
+        'chef_environment': str,
+        'policy_name': str,
+        'policy_group': str
     }
 
     def has_key(self, key):


### PR DESCRIPTION
Prior to this change, policy_name and policy_group would get set to `null` on Node.save().