### PR TITLE
Handle another exception where value is None

### DIFF
--- a/chef/base.py
+++ b/chef/base.py
@@ -58,6 +58,8 @@ class ChefObject(six.with_metaclass(ChefObjectMeta, object)):
                 data = self.api[self.url]
             except ChefServerNotFoundError:
                 pass
+            except TypeError:
+                pass
             else:
                 self.exists = True
         self._populate(data)


### PR DESCRIPTION
In some environments an error occurs with the following message:

> Traceback (most recent call last):
  File "./get_invalid_instances.py", line 412, in <module>
    main()
  File "./get_invalid_instances.py", line 47, in main
    invalid_instances.get_invalid_chef_node_instances()
  File "./get_invalid_instances.py", line 145, in get_invalid_chef_node_instances
    if self.check_chef_node(hostname) is not True:
  File "./get_invalid_instances.py", line 204, in check_chef_node
    chef_node = chef.Node(hostname, api=self.chef_api_client).run_list
  File "/usr/local/lib/python3.4/dist-packages/chef/base.py", line 60, in __init__
    data = self.api[self.url]
TypeError: 'NoneType' object is not subscriptable

The modification done allows the data variable to be empty if self.api is empty.